### PR TITLE
Update snapdragon to 0.11

### DIFF
--- a/lib/compilers.js
+++ b/lib/compilers.js
@@ -42,7 +42,7 @@ module.exports = function(brackets) {
      */
 
     .set('bracket', function(node) {
-      return this.mapVisit(node.nodes);
+      return this.mapVisit(node);
     })
     .set('bracket.open', function(node) {
       return this.emit(node.val, node);

--- a/lib/parsers.js
+++ b/lib/parsers.js
@@ -1,7 +1,6 @@
 'use strict';
 
 var utils = require('./utils');
-var define = require('define-property');
 
 /**
  * Text regex
@@ -19,7 +18,7 @@ function parsers(brackets) {
   brackets.parser.sets.bracket = brackets.parser.sets.bracket || [];
   brackets.parser
 
-    .capture('escape', function() {
+    .set('escape', function() {
       if (this.isInside('bracket')) return;
       var pos = this.position();
       var m = this.match(/^\\(.)/);
@@ -35,7 +34,7 @@ function parsers(brackets) {
      * Text parser
      */
 
-    .capture('text', function() {
+    .set('text', function() {
       if (this.isInside('bracket')) return;
       var pos = this.position();
       var m = this.match(not);
@@ -51,7 +50,7 @@ function parsers(brackets) {
      * POSIX character classes: "[[:alpha:][:digits:]]"
      */
 
-    .capture('posix', function() {
+    .set('posix', function() {
       var pos = this.position();
       var m = this.match(/^\[:(.*?):\](?=.*\])/);
       if (!m) return;
@@ -73,13 +72,13 @@ function parsers(brackets) {
      * Bracket (noop)
      */
 
-    .capture('bracket', function() {})
+    .set('bracket', function() {})
 
     /**
      * Open: '['
      */
 
-    .capture('bracket.open', function() {
+    .set('bracket.open', function() {
       var parsed = this.parsed;
       var pos = this.position();
       var m = this.match(/^\[(?=.*\])/);
@@ -110,20 +109,19 @@ function parsers(brackets) {
 
       var node = pos({
         type: 'bracket',
-        nodes: [open]
+        nodes: []
       });
 
-      define(node, 'parent', prev);
-      define(open, 'parent', node);
       this.push('bracket', node);
-      prev.nodes.push(node);
+      this.pushNode(node, prev);
+      this.pushNode(open, node);
     })
 
     /**
      * Bracket text
      */
 
-    .capture('bracket.inner', function() {
+    .set('bracket.inner', function() {
       if (!this.isInside('bracket')) return;
       var pos = this.position();
       var m = this.match(not);
@@ -161,7 +159,7 @@ function parsers(brackets) {
      * Close: ']'
      */
 
-    .capture('bracket.close', function() {
+    .set('bracket.close', function() {
       var parsed = this.parsed;
       var pos = this.position();
       var m = this.match(/^\]/);
@@ -201,8 +199,7 @@ function parsers(brackets) {
         return node;
       }
 
-      bracket.nodes.push(node);
-      define(node, 'parent', bracket);
+      this.pushNode(node, bracket);
     });
 }
 

--- a/package.json
+++ b/package.json
@@ -27,12 +27,11 @@
     "test": "mocha"
   },
   "dependencies": {
-    "debug": "^2.3.3",
-    "define-property": "^0.2.5",
-    "extend-shallow": "^2.0.1",
-    "posix-character-classes": "^0.1.0",
+    "debug": "^3.1.0",
+    "extend-shallow": "^3.0.2",
+    "posix-character-classes": "^1.0.0",
     "regex-not": "^1.0.0",
-    "snapdragon": "^0.8.1",
+    "snapdragon": "^0.11.3",
     "to-regex": "^3.0.1"
   },
   "devDependencies": {

--- a/test/wildmatch.js
+++ b/test/wildmatch.js
@@ -13,6 +13,7 @@ describe('original wildmatch', function() {
     assert(match.isMatch('a-b', 'a[]-]b'));
     assert(match.isMatch('a]b', 'a[]-]b'));
     assert(match.isMatch('a]b', 'a[]]b'));
+    assert(match.isMatch('a[]b', 'a[]b'));
     assert(match.isMatch('aab', 'a[]a-]b'));
     assert(match.isMatch('ten', 't[a-g]n'));
     assert(match.isMatch('ton', 't[!a-g]n'));
@@ -102,7 +103,6 @@ describe('original wildmatch', function() {
     assert(!match.isMatch('\\]', '[\\]]'));
     assert(!match.isMatch(']', '[\\\\-^]'));
     assert(!match.isMatch('^', '[]-a]'));
-    assert(!match.isMatch('a[]b', 'a[]b'));
     assert(!match.isMatch('ab', '[!'));
     assert(!match.isMatch('ab', '[-'));
     assert(!match.isMatch('ab', 'a[]b'));


### PR DESCRIPTION
- Updates all dependencies including snapdragon, non of them introduced a breaking change for expand-brackets afaics
- Updates code to support new snapdragon
- This is a breaking change ! 💥
- Moves one test from `!match` to `match` as it matches now. After investigating why this happens, it seems that before it was not matching by mistake. I tested with `minimatch` and `multimatch` and both also match

```
❯ node
> var mm = require("minimatch");
undefined
> mm("a[]b", "a[]b");
true
> mm("a[b", "a[]b");
false
> mm("a[]b", "a[]b");
true
> mm.makeRe("a[]b")
/^(?:a\[\]b)$/
>
```

The produced regex from mm is now also exactly the same as in this lib. Without this PR `expand-brackets` is producing `/^(?:a\[\\\]b)$/` which seems wrong. But please check you probably know better.

this is a requirement for updating snapdragon in micromatch.